### PR TITLE
Fix base_link mass value because too little mass becomes 0 due to rounding error

### DIFF
--- a/echo_bot_description/urdf/base/echo_bot_base.urdf.xacro
+++ b/echo_bot_description/urdf/base/echo_bot_base.urdf.xacro
@@ -24,7 +24,7 @@
         </geometry>      
       </collision>
       <inertial>
-        <mass value="1e-06" />
+        <mass value="1e-05" />
         <origin xyz="0 0 0" rpy="0 0 0" />
         <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0" />
       </inertial>


### PR DESCRIPTION
gazebo のモデルにおける mass や inertia は、小さすぎる場合は無視されることがあります。
無視されると物理モデルとして破綻するので、gazebo には正常に読み込まれません。

![image](https://user-images.githubusercontent.com/948400/79140631-3cdf1800-7df3-11ea-985f-d9e7c59e0889.png)
